### PR TITLE
viteのバージョンを6.4.2に変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "turbo": "^2.4.2",
     "typescript": "5.8.1-rc",
     "typescript-eslint": "^8.20.0",
-    "vite": "6.1.0"
+    "vite": "6.4.2"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json}": [


### PR DESCRIPTION
viteのバージョンについて、6.1.0はまずいらしいので、6.4.2に変更